### PR TITLE
fix:  ensure CRD subchart version calculation uses the correct upstream value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore(deps): update vendir https://github.com/kubeedge/kubeedge to v1.23.1
 
+### Fixed
+
+- Fix CRD subchart version calculation.
+
 ## [0.5.0] - 2026-04-07
 
 ### Changed

--- a/sync/patches/crds/patch.sh
+++ b/sync/patches/crds/patch.sh
@@ -37,9 +37,11 @@ fi
 
 if [[ $CRDS_CHANGED -eq 1 ]]; then
     # CRDs have changed in this release, set the CRD chart version to match the upstream version we're syncing against
-    CRD_CHART_VERSION=$(grep '^version:' vendor/kubeedge-cloudcore/manifests/charts/cloudcore/Chart.yaml | awk '{print $2}')
+    CRD_CHART_VERSION=$(yq -r .directories[0].contents[0].git.ref "${REPO_DIR}"/vendir.yml)
+    # remove leading 'v' if present
+    CRD_CHART_VERSION="${CRD_CHART_VERSION#v}"
 else
-    # no change to CRDs, ensure the CRD chart version is not bumped by setting it to the current published version 
+    # no change to CRDs, ensure the CRD chart version is not bumped by setting it to the current published version
     CRD_CHART_VERSION=$(curl --silent https://raw.githubusercontent.com/giantswarm/kubeedge-cloudcore-app/refs/heads/main/helm/kubeedge-cloudcore/charts/kubeedge-cloudcore-crds/Chart.yaml | yq .version -r)
 fi
 


### PR DESCRIPTION
the patching logic for the CRD subchart pulled the upstream chart version from the wrong place, potentially causing the chart's version to jump backwards. This PR pulls the version from `vendir.yml` which is the source of truth for the upstream chart version we are tracking.

### Checklist

- [x] Update changelog in CHANGELOG.md.
